### PR TITLE
Added mixed to many()

### DIFF
--- a/src/Rut.php
+++ b/src/Rut.php
@@ -137,7 +137,7 @@ class Rut implements ArrayAccess, JsonSerializable, Serializable
      * Makes many Rut instances from a given array, discarding malformed ones.
      *
      * @param  array $ruts
-     * @return array
+     * @return array|mixed
      */
     public static function many(...$ruts)
     {


### PR DESCRIPTION
This allows to correctly type hint the result if callbacks are used that returns anything more than an array.